### PR TITLE
update mapml viewer to use CDN

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -481,41 +481,41 @@ GEOLOCATOR.init =  async function(view){
  * @return {undefined}
  */
 GEOLOCATOR.initializeMapML = async function(coords, geoMarkers){
-    GEOLOCATOR.mymap = document.getElementById('mapml-view')
-    GEOLOCATOR.mymap.setAttribute("lat", coords[0])
-    GEOLOCATOR.mymap.setAttribute("long", coords[1])
-    let feature_layer = `<layer- label="RERUM Geolocation Assertions" checked="checked">`
-    feature_layer += `<map-meta name="projection" content="OSMTILE"></map-meta>`
-    feature_layer += `<map-meta name="cs" content="gcrs"></map-meta>`
-    feature_layer += `<map-meta name="extent" content="top-left-longitude=-180,top-left-latitude=84,bottom-right-longitude=180,bottom-right-latitude=-84"></map-meta>`
+    GEOLOCATOR.mymap = document.getElementById('mapml-view');
+    // https://maps4html.org/web-map-doc/docs/api/mapml-viewer-api#zoomtolat-lon-zoom
+    GEOLOCATOR.mymap.zoomTo(coords[0],coords[1],GEOLOCATOR.mymap.zoom);
+    let feature_layer = `<layer- label="RERUM Geolocation Assertions" checked="checked">
+    <map-meta name="projection" content="OSMTILE"></map-meta>
+    <map-meta name="cs" content="gcrs"></map-meta>
+  <map-meta name="extent" content="top-left-longitude=-180,top-left-latitude=84,bottom-right-longitude=180,bottom-right-latitude=-84"></map-meta>`;
     let mapML_features = geoMarkers.map(geojson_feature => {
         //We need each of these to be a <feature>.  Right now, they are GeoJSON-LD
-        let feature_creator = geojson_feature.properties.creator
-        let feature_web_URI = geojson_feature.properties.annoID
-        let feature_label = geojson_feature.properties.label
-        let feature_caption = `<map-featurecaption>${feature_label}</map-featurecaption>`
-        let feature_description = geojson_feature.properties.description
-        let feature_describes = geojson_feature.properties.targetID
-        let feature_lat = geojson_feature.geometry.coordinates[0]
-        let feature_long = geojson_feature.geometry.coordinates[1]
-        let geometry = `<map-geometry><map-point><map-coordinates>${feature_lat} ${feature_long}</map-coordinates></map-point></map-geometry>`
+        let feature_creator = geojson_feature.properties.creator;
+        let feature_web_URI = geojson_feature.properties.annoID;
+        let feature_label = geojson_feature.properties.label;
+        let feature_caption = `<map-featurecaption>${feature_label}</map-featurecaption>`;
+        let feature_description = geojson_feature.properties.description;
+        let feature_describes = geojson_feature.properties.targetID;
+        let feature_lat = geojson_feature.geometry.coordinates[0];
+        let feature_long = geojson_feature.geometry.coordinates[1];
+        let geometry = `<map-geometry><map-point><map-coordinates>${feature_lat} ${feature_long}</map-coordinates></map-point></map-geometry>`;
         let properties = 
         `<map-properties>
             <p>Label: ${feature_label}</p>
             <p>Description: ${feature_description}</p>
             <p><a target="_blank" href="${feature_describes}">Web Resource</a></p>
             <p><a target="_blank" href="${feature_web_URI}">Web Annotation</a></p>
-        </map-properties>`
-        let feature = `<map-feature class="generic_point">${feature_caption} ${properties} ${geometry}</map-feature>`
-        return feature
-    })
-    mapML_features = mapML_features.join(" ")
-    feature_layer += `${mapML_features}</layer->` 
-    document.getElementById('mapml-container').style.backgroundImage = "none"
-    loadingMessage.classList.add("is-hidden")
+        </map-properties>`;
+        let feature = `<map-feature class="generic_point">${feature_caption} ${properties} ${geometry}</map-feature>`;
+        return feature;
+    });
+    mapML_features = mapML_features.join(" ");
+    feature_layer += `${mapML_features}</layer->`; 
+    document.getElementById('mapml-container').style.backgroundImage = "none";
+    loadingMessage.classList.add("is-hidden");
     //Add the features to the mapml-viewer dynamically
-    GEOLOCATOR.mymap.innerHTML += feature_layer
-}
+    GEOLOCATOR.mymap.innerHTML += feature_layer;
+};
     
 GEOLOCATOR.initializeLeaflet = async function(coords, geoMarkers){
     GEOLOCATOR.mymap = L.map('leafletInstanceContainer')   
@@ -588,7 +588,7 @@ GEOLOCATOR.goToCoords = function(event, view  ){
             default:
         }
         document.getElementById("currentCoords").innerHTML = "["+coords.toString()+"]"
-        window.scrollTo(0, leafletInstanceContainer.offsetTop - 5)
+//        window.scrollTo(0, leafletInstanceContainer.offsetTop - 5)
     }
 }
 

--- a/web/mapML-view.html
+++ b/web/mapML-view.html
@@ -10,8 +10,7 @@ and open the template in the editor.
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="stylesheet" href="https://unpkg.com/chota@latest">
-        <script type="module" src="https://geogratis.gc.ca/mapml/client/web-map/mapml-viewer.js" crossorigin></script>
-        <!--<script type="module" src="https://geogratis.gc.ca/mapml/client/web-map/web-map.js" crossorigin></script>-->
+        <script type="module" src="https://unpkg.com/@maps4html/web-map-custom-element@0.11.0/dist/mapml-viewer.js" crossorigin></script>
         <script src="js/app.js"></script>  
         <style>
             body{
@@ -182,14 +181,20 @@ and open the template in the editor.
         <div class="container">
             <p class="howTo" id='howTo'> 
                 View the map below for rendered Web Annotation geographic assertions created by this application.  Pan and zoom are supported. 
-                Supplying direct coordinates is available below the map. <a onclick="GEOLOCATOR.mymap.flyTo([12,12],2)">[Shift] + [Z]</a> 
+                Supplying direct coordinates is available below the map. <a onclick="GEOLOCATOR.mymap.zoomTo(12,12,2)">[Shift] + [Z]</a>  
                 will zoom out for a holistic view.  Click the tab below the map to filter showing only assertions with IIIF targets or all assertions.  
                 Clicking any blue point on the map will show applicable information about the target when the URI is resolvable.
             </p>
             <div id="mapml-container">
                 <div id="loadingMessage" style="text-align: center;">Gathering Resource Data From Around The World...</div>
-                <mapml-viewer is="web-map" id="mapml-view" projection="OSMTILE" zoom="2" lat="0.0" lon="0.0" controls>
-                    <layer- label="OSM Layer" src="https://geogratis.gc.ca/mapml/en/osmtile/osm/" checked="checked"></layer->
+                <mapml-viewer id="mapml-view" projection="OSMTILE" zoom="2" lat="0.0" lon="0.0" controls>
+                  <layer- label="OSM Layer" checked>
+                    <map-extent units="OSMTILE">
+                      <map-input name="z" type="zoom" value="18" min="0" max="18"></map-input>  
+                      <map-input name="s" type="hidden" shard="true" list="servers"></map-input>
+                      <map-input name="x" type="location" units="tilematrix" axis="column" min="0" max="262144"></map-input><map-input name="y" type="location" units="tilematrix" axis="row" min="0" max="262144"></map-input>
+                      <map-link rel="tile" tref="https://tile.openstreetmap.org/{z}/{x}/{y}.png"></map-link></map-extent>
+                  </layer->
                 </mapml-viewer>
             </div>
 <!--            <div class="col">
@@ -222,7 +227,7 @@ and open the template in the editor.
     <script>
         
         //let latlang = [38.6360699, -90.2348349] //SLU in lat,long order
-        GEOLOCATOR.init("mapML")
+        GEOLOCATOR.init("mapML");
         /**
          * Use Shift + Z to do the zoom out to xsee dots across the globe.
          */


### PR DESCRIPTION
The viewer is released on npm and as it is, the viewer gets pushed to unpkg so probably best to use that version.  Further updates are possible, now that the [\<mapml-viewer> viewer supports GeoJSON](https://maps4html.org/web-map-doc/docs/api/mapml-viewer-api#geojson2mapmljson-options), if desired.